### PR TITLE
Added support for ssl_prefer_server_ciphers option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,7 @@ class dovecot (
   $ssl_key                    = '/etc/pki/dovecot/private/dovecot.pem',
   $ssl_cipher_list            = undef,
   $ssl_protocols              = undef,
+  $ssl_prefer_server_ciphers  = undef,
   # 15-lda.conf
   $postmaster_address         = undef,
   $hostname                   = undef,

--- a/templates/conf.d/10-ssl.conf.erb
+++ b/templates/conf.d/10-ssl.conf.erb
@@ -52,3 +52,8 @@ ssl_cipher_list = <%= @ssl_cipher_list %>
 ssl_protocols = <%= @ssl_protocols %>
 <% end -%>
 
+# Prefer the server's order of ciphers over client's.
+#ssl_prefer_server_ciphers = no
+<% if @ssl_prefer_server_ciphers -%>
+ssl_prefer_server_ciphers = <%= @ssl_prefer_server_ciphers %>
+<% end -%>


### PR DESCRIPTION
Hello!

This PR add the paramater ssl_prefer_server_ciphers to configure the option ssl_prefer_server_ciphers in dovecot.

If ssl_prefer_server_ciphers this on, the server prefer the ssl cipher which is used. 

This option is new in dovecot 2.2. 
